### PR TITLE
Fixed possible typo by replacing ICurioStackHandler with ICurioStacksHandler

### DIFF
--- a/docs/curios/inventory/basic-inventory.md
+++ b/docs/curios/inventory/basic-inventory.md
@@ -52,12 +52,12 @@ whether the developer wants to access all of the slot inventories or just a part
 
 ### Accessing the entire inventory
 
-The entire Curios inventory exists as a `Map<String, ICurioStackHandler>`, with the slot type identifiers acting as each
-key and the `ICurioStackHandler` acting as the inventory attached to the slot type. To access this, the `getCurios`
+The entire Curios inventory exists as a `Map<String, ICurioStacksHandler>`, with the slot type identifiers acting as each
+key and the `ICurioStacksHandler` acting as the inventory attached to the slot type. To access this, the `getCurios`
 method can be used:
 
 ```java
-Map<String, ICurioStackHandler> curios = curiosInventory.getCurios();
+Map<String, ICurioStacksHandler> curios = curiosInventory.getCurios();
 ```
 :::caution
 This returns an **unmodifiable** map so attempts to change the structure of the map directly through this method, such
@@ -76,7 +76,7 @@ curios.forEach((identifier, slotInventory) -> {
 Or developers can access a particular sub-inventory, such as a slot type with the `"ring"` identifier:
 
 ```java
-ICurioStackHandler slotInventory = curios.get("ring");
+ICurioStacksHandler slotInventory = curios.get("ring");
 
 // null check to ensure that the slot inventory exists
 if (slotInventory != null) {
@@ -93,7 +93,7 @@ In order to access a particular inventory for slot type, developers can either a
 in the preceding section or skip straight to a sub-inventory for that slot type:
 
 ```java
-Optional<ICurioStackHandler> slotInventory = curiosInventory.getStacksHandler("ring");
+Optional<ICurioStacksHandler> slotInventory = curiosInventory.getStacksHandler("ring");
 ```
 
 The above code will retrive an `Optional` for the slot inventory with the `"ring"` identifier passed into the


### PR DESCRIPTION
I tried to follow the docs in https://docs.illusivesoulworks.com/curios/inventory/basic-inventory but got errors until I changed  `ICurioStackHandler `to `ICurioStacksHandler`. 

I found [ICurioStacksHandler.java](https://github.com/TheIllusiveC4/Curios/blob/1.21.4/src/main/java/top/theillusivec4/curios/api/type/inventory/ICurioStacksHandler.java) so I guess the missing 's' is a typo?

Thanks for your work on the cool mod/api by the way.